### PR TITLE
link nuget package with github repo using metadata

### DIFF
--- a/Selone/Selone.csproj
+++ b/Selone/Selone.csproj
@@ -10,6 +10,9 @@
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net45</TargetFramework>
+    <PackageLicenseUrl>https://github.com/skbkontur/Selone/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/skbkontur/Selone</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/skbkontur/Selone</RepositoryUrl>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\Build\Selone\</OutputPath>


### PR DESCRIPTION
according to https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties.

With this changes it will be possible navigate to github repository and license from https://www.nuget.org/packages/Kontur.Selone/