### PR TITLE
check if session is not null before Enqueue

### DIFF
--- a/Selone.Tests/Tests/WebDrivers/WebDriverPoolTests.cs
+++ b/Selone.Tests/Tests/WebDrivers/WebDriverPoolTests.cs
@@ -3,6 +3,7 @@ using Kontur.Selone.Extensions;
 using Kontur.Selone.Tests.Browsers;
 using Kontur.Selone.WebDrivers;
 using NUnit.Framework;
+using OpenQA.Selenium;
 
 namespace Kontur.Selone.Tests.Tests.WebDrivers
 {
@@ -28,6 +29,28 @@ namespace Kontur.Selone.Tests.Tests.WebDrivers
                 Thread.Sleep(1000);
             }
 
+            webDriverPool.Clear();
+        }
+
+        [Test]
+        public void Create_New_WebDriver_Instance_When_Previous_Was_Disposed()
+        {
+            var webDriverPool = new WebDriverPool(BrowserPool.ChromeDriverFactory, new DelegateWebDriverCleaner(x =>
+            {
+                x.ResetWindows();
+                x.Quit();
+            }));
+            
+            var webDriver = webDriverPool.Acquire();
+            var sessionId1 = ((IHasSessionId)webDriver).SessionId;
+            webDriverPool.Release(webDriver);
+
+            webDriver = webDriverPool.Acquire();
+            var sessionId2 = ((IHasSessionId)webDriver).SessionId;
+            webDriverPool.Release(webDriver);
+            
+            Assert.AreNotEqual(sessionId1, sessionId2);
+            
             webDriverPool.Clear();
         }
     }

--- a/Selone/Selone.csproj
+++ b/Selone/Selone.csproj
@@ -7,7 +7,7 @@
     <Product>Kontur.Selone</Product>
     <RootNamespace>Kontur.Selone</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <LangVersion>latest</LangVersion>
     <PackageLicense>https://github.com/skbkontur/Selone/blob/master/LICENSE</PackageLicense>
     <PackageProjectUrl>https://github.com/skbkontur/Selone</PackageProjectUrl>

--- a/Selone/WebDrivers/WebDriverPool.cs
+++ b/Selone/WebDrivers/WebDriverPool.cs
@@ -55,7 +55,11 @@ namespace Kontur.Selone.WebDrivers
             }
 
             cleaner?.Clear(webDriver);
-            queue.Enqueue(webDriver);
+
+            if (((IHasSessionId)webDriver).SessionId != null)
+            {
+                queue.Enqueue(webDriver);
+            }
         }
     }
 }


### PR DESCRIPTION
IWebDriverCleaner позволяет почистить браузер от теста, в том числе с помощью клинера можно закрыть браузер (Quit), т.к. он этого не запрещает делать. Такое может понадобиться, если по каким-то причинам не получается полностью почистить браузер от прошлого теста. 
Например, не удается вычистить localStorage, потому что в конце теста мы оказываемся не в домене, в котором хранятся какие-то данные стореджа. В этом случае безопаснее и дешевле просто закрыть браузер и создать новый.

В текущей реализации WebDriverPool нет никакой защиты от того, что в пул может вернуться задиспоузеный экземпляр вебдрайвера. Следовательно, если следующий тест возьмет такой вебдрайвер, то он свалится, ибо браузера уже не существует.

Эту проблему можно решить на стороне пользователей библиотеки, например делать проверку жив ли вебдрайвер перед тем как его возвращать в пул, либо делать try/catch на aquire и если вытащенный из пула вебдрайвер уже убитый, то пробовать вытаскивать другой, но это все видится как костыль, который придется писать каждому, кто использует библиотеку и столкнулся с такой проблемой.

Поэтому решил проверку в release затащить в саму библиоетку.