### PR TITLE
Remove legacy code from tests

### DIFF
--- a/Selone.Tests/Browsers/BrowserPool.cs
+++ b/Selone.Tests/Browsers/BrowserPool.cs
@@ -8,9 +8,7 @@ namespace Kontur.Selone.Tests.Browsers
     {
         public static readonly ChromeDriverFactory ChromeDriverFactory = new ChromeDriverFactory(new ChromeDriverFactoryConfiguration
         {
-            ChromeDirectoryPath = @"C:\browsers\Chrome",
-            DriverDirectoryPath = @"C:\browsers\Chrome",
-            WindowSize = new WindowSize {Width = 800, Height = 600}
+            WindowSize = new WindowSize {Width = 1024, Height = 768}
         });
 
         public static readonly InternetExplorerDriverFactory InternetExplorerDriverFactory = new InternetExplorerDriverFactory(new InternetExplorerDriverFactoryConfiguration

--- a/Selone.Tests/Browsers/Factories/ChromeDriverFactory.cs
+++ b/Selone.Tests/Browsers/Factories/ChromeDriverFactory.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using Kontur.Selone.Extensions;
+﻿using Kontur.Selone.Extensions;
 using Kontur.Selone.WebDrivers;
-using Microsoft.Win32;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 
@@ -11,70 +7,34 @@ namespace Kontur.Selone.Tests.Browsers.Factories
 {
     public class ChromeDriverFactory : IWebDriverFactory
     {
-        private const string RegistryKey = @"Software\Google\Update\Clients\{8A69D345-D564-463c-AFF1-A69D9E530F96}";
         private readonly ChromeDriverFactoryConfiguration configuration;
-        private readonly string chromeExe;
 
         public ChromeDriverFactory(ChromeDriverFactoryConfiguration configuration)
         {
             this.configuration = configuration;
-            chromeExe = Path.Combine(configuration.ChromeDirectoryPath, "chrome.exe");
         }
 
         public IWebDriver Create()
         {
-            SetChromeVersionToRegistry(chromeExe);
-            for (var i = 0; i < 3; i++)
-            {
-                try
-                {
-                    var chromeDriverService = CreateChromeDriverService();
-                    var options = CreateChromeOptions(chromeExe);
-                    return CreateChromeDriver(chromeDriverService, options);
-                }
-                //ошибка возникает периодически
-                //предложение: перейти на новую версию chromedriver (сейчас 2.24, chrome - 53)
-                //но в настоящий момент при переходе на новую версию драйвера возможны ошибки другого рода
-                //решение: подождать стабилизации новой версии, после чего перейти на нее и удалить ретраи
-                catch (InvalidOperationException e) when (e.Message.Contains("session not created exception"))
-                {
-                }
-            }
-
-            return null;
+            var chromeDriverService = CreateChromeDriverService();
+            var options = CreateChromeOptions();
+            return CreateChromeDriver(chromeDriverService, options);
         }
 
-        private static void SetChromeVersionToRegistry(string chromeExe)
+        private static ChromeOptions CreateChromeOptions()
         {
-            var key = Registry.CurrentUser.CreateSubKey(RegistryKey);
-            if (key == null)
-            {
-                throw new Exception($"Не удалось создать ключ {Registry.CurrentUser}\\{RegistryKey}");
-            }
-
-            key.SetValue("pv", FileVersionInfo.GetVersionInfo(chromeExe).ProductVersion);
-            key.Close();
-        }
-
-        private static ChromeOptions CreateChromeOptions(string chromeExe)
-        {
-            //"--no-sandbox" добавлен, потому что столкнулись с проблемой: Chrome падает сразу же после запуска
-            //подробнее тут: https://sites.google.com/a/chromium.org/chromedriver/help/chrome-doesn-t-start
-            var options = new ChromeOptions {BinaryLocation = chromeExe};
-            options.AddArguments("--no-sandbox", "--start-maximized", "--disable-extensions");
+            var options = new ChromeOptions();
             return options;
         }
 
         private ChromeDriverService CreateChromeDriverService()
         {
-            return ChromeDriverService.CreateDefaultService(configuration.DriverDirectoryPath);
+            return ChromeDriverService.CreateDefaultService();
         }
 
         private IWebDriver CreateChromeDriver(ChromeDriverService chromeDriverService, ChromeOptions options)
         {
-            //commandTimeout увеличен с дефолтных 60 до 180 секунд, т.к. при 60 время от времени получаем таймаут
-            //подробнее тут: https://github.com/SeleniumHQ/selenium/wiki/DotNet-Bindings
-            var chromeDriver = new ChromeDriver(chromeDriverService, options, TimeSpan.FromSeconds(180));
+            var chromeDriver = new ChromeDriver(chromeDriverService, options);
             chromeDriver.Manage().Window.SetSize(configuration.WindowSize.Width, configuration.WindowSize.Height);
             return chromeDriver;
         }

--- a/Selone.Tests/Browsers/Factories/ChromeDriverFactoryConfiguration.cs
+++ b/Selone.Tests/Browsers/Factories/ChromeDriverFactoryConfiguration.cs
@@ -4,10 +4,6 @@
     {
         private WindowSize windowSize;
 
-        public string ChromeDirectoryPath { get; set; }
-
-        public string DriverDirectoryPath { get; set; }
-
         public WindowSize WindowSize { get => windowSize ?? (windowSize = new WindowSize()); set => windowSize = value; }
     }
 }

--- a/Selone.Tests/Selone.Tests.csproj
+++ b/Selone.Tests/Selone.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Kontur.Selone.Tests</AssemblyName>
     <Authors>Kontur</Authors>
     <Company>Kontur</Company>
@@ -24,10 +24,6 @@
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
-    <PackageReference Include="Microsoft.Win32.Registry">
-      <Version>4.7.0</Version>
-    </PackageReference>
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
now the newest version of ChromeDriver is always used. still Windows only