### PR TITLE
new WebDriver and other dependencies

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/Selone.Tests/Extensions/ScreenshotExtensions.cs
+++ b/Selone.Tests/Extensions/ScreenshotExtensions.cs
@@ -23,7 +23,7 @@ namespace Kontur.Selone.Tests.Extensions
             var screenshotPath = Path.Combine(dir, filename);
             try
             {
-                screenshot.SaveAsFile(screenshotPath, ScreenshotImageFormat.Png);
+                screenshot.SaveAsFile(screenshotPath);
                 Console.WriteLine($"Screenshot saved to '{screenshotPath}'");
                 if (TeamcityHelper.IsTeamCity())
                 {

--- a/Selone.Tests/Selone.Tests.csproj
+++ b/Selone.Tests/Selone.Tests.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Kontur.Selone.Tests</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\Build\Selone.Tests\</OutputPath>
@@ -18,14 +18,16 @@
   <ItemGroup>
     <ProjectReference Include="..\Selone\Selone.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Kontur.RetryableAssertions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="*" />
   </ItemGroup>
 </Project>

--- a/Selone.Tests/Tests/WebDrivers/WebDriverPoolTests.cs
+++ b/Selone.Tests/Tests/WebDrivers/WebDriverPoolTests.cs
@@ -20,7 +20,7 @@ namespace Kontur.Selone.Tests.Tests.WebDrivers
             using (var pooled = webDriverPool.AcquireWrapper())
             {
                 var webDriver = pooled.WrappedDriver;
-                webDriver.Navigate().GoToUrl("http://google.com");
+                webDriver.Navigate().GoToUrl("https://google.com");
                 Thread.Sleep(1000);
             }
 
@@ -29,7 +29,7 @@ namespace Kontur.Selone.Tests.Tests.WebDrivers
             {
                 var webDriver = pooled.WrappedDriver;
                 Assert.That(webDriver.Url, Is.EqualTo("about:blank"));
-                webDriver.Navigate().GoToUrl("http://google.com");
+                webDriver.Navigate().GoToUrl("https://google.com");
                 Thread.Sleep(1000);
             }
 
@@ -83,14 +83,14 @@ namespace Kontur.Selone.Tests.Tests.WebDrivers
             var firstUsingDrivers = new[] {driverPool.Acquire(), driverPool.Acquire()};
             foreach (var driver in firstUsingDrivers)
             {
-                driver.Navigate().GoToUrl("https://kontur.ru");
+                driver.Navigate().GoToUrl("https://ya.ru");
                 driverPool.Release(driver);
             }
 
             var secondUsingDrivers = new[] {driverPool.Acquire(), driverPool.Acquire()};
             foreach (var driver in secondUsingDrivers)
             {
-                driver.Navigate().GoToUrl("https://kontur.ru/press/news");
+                driver.Navigate().GoToUrl("https://ya.ru/pogoda");
                 driverPool.Release(driver);
             }
 

--- a/Selone/Elements/ElementsCollection.cs
+++ b/Selone/Elements/ElementsCollection.cs
@@ -42,7 +42,7 @@ namespace Kontur.Selone.Elements
             }
             catch (NoSuchElementException)
             {
-                return new IWebElement[0];
+                return Array.Empty<IWebElement>();
             }
         }
 

--- a/Selone/Elements/WebElementWrapper.cs
+++ b/Selone/Elements/WebElementWrapper.cs
@@ -111,12 +111,6 @@ namespace Kontur.Selone.Elements
             return Execute(x => x.GetCssValue(propertyName));
         }
 
-        [Obsolete("Use the GetDomProperty method instead")]
-        public string GetProperty(string propertyName)
-        {
-            return Execute(x => x.GetProperty(propertyName));
-        }
-
         public void Execute(Action<IWebElement> action)
         {
             Execute(x =>
@@ -131,25 +125,25 @@ namespace Kontur.Selone.Elements
             var attempts = 5;
             while (true)
             {
-                var hasAttemts = --attempts > 0;
+                var hasAttempts = --attempts > 0;
                 cachedElement ??= searchContext.FindElement(by);
                 try
                 {
                     return func(cachedElement);
                 }
-                catch (InvalidElementStateException) when (hasAttemts)
+                catch (InvalidElementStateException) when (hasAttempts)
                 {
                     InvalidateCachedElement();
                 }
-                catch (StaleElementReferenceException) when (hasAttemts)
+                catch (StaleElementReferenceException) when (hasAttempts)
                 {
                     InvalidateCachedElement();
                 }
-                catch (InvalidOperationException exception) when (hasAttemts && IsElementIsNotClickableAtPointException(exception))
+                catch (InvalidOperationException exception) when (hasAttempts && IsElementIsNotClickableAtPointException(exception))
                 {
                     ScrollToCachedElement();
                 }
-                catch (ElementNotVisibleException) when (hasAttemts)
+                catch (ElementNotInteractableException) when (hasAttempts)
                 {
                     ScrollToCachedElement();
                 }

--- a/Selone/Extensions/SearchContextExtensions.cs
+++ b/Selone/Extensions/SearchContextExtensions.cs
@@ -3,7 +3,6 @@ using Kontur.Selone.Elements;
 using Kontur.Selone.Selectors;
 using Kontur.Selone.Selectors.Context;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Internal;
 
 namespace Kontur.Selone.Extensions
 {

--- a/Selone/Extensions/WebElementExtensions.cs
+++ b/Selone/Extensions/WebElementExtensions.cs
@@ -6,7 +6,6 @@ using Kontur.Selone.Elements;
 using Kontur.Selone.Properties;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
-using OpenQA.Selenium.Internal;
 
 namespace Kontur.Selone.Extensions
 {
@@ -89,7 +88,7 @@ namespace Kontur.Selone.Extensions
 
         public static IProp<bool> Present(this IWebElement webElement)
         {
-            return webElement.PropertyNoCheck(IsPresent, "IsPreset");
+            return webElement.PropertyNoCheck(IsPresent, "IsPresent");
         }
 
         public static IProp<bool> Visible(this IWebElement webElement)
@@ -154,7 +153,7 @@ namespace Kontur.Selone.Extensions
 
         public static IProp<T> Property<T>(this IWebElement webElement, Func<IWebElement, T> getValue, string description)
         {
-            return Prop.Create(() => webElement.IsVisible() ? getValue(webElement) : throw new ElementNotVisibleException("not visible"), description);
+            return Prop.Create(() => webElement.IsVisible() ? getValue(webElement) : throw new ElementNotInteractableException("not visible"), description);
         }
 
         public static IProp<T> PropertyNoCheck<T>(this IWebElement webElement, Func<IWebElement, T> getValue, string description)
@@ -178,13 +177,13 @@ namespace Kontur.Selone.Extensions
         {
             try
             {
-                return webElement.Execute(x => x.Displayed && x.Size.Height > 0 && x.Size.Width > 0 ? true : throw new ElementNotVisibleException());
+                return webElement.Execute(x => x.Displayed && x.Size.Height > 0 && x.Size.Width > 0 ? true : throw new ElementNotInteractableException());
             }
             catch (NoSuchElementException)
             {
                 return false;
             }
-            catch (ElementNotVisibleException)
+            catch (ElementNotInteractableException)
             {
                 return false;
             }

--- a/Selone/Selone.csproj
+++ b/Selone/Selone.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>Kontur.Selone</AssemblyName>
     <Authors>Kontur</Authors>
     <Company>Kontur</Company>
@@ -19,10 +19,10 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>..\Build\Selone\</OutputPath>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.31.0" />
   </ItemGroup>
 </Project>

--- a/Selone/Selone.csproj
+++ b/Selone/Selone.csproj
@@ -7,7 +7,7 @@
     <Product>Kontur.Selone</Product>
     <RootNamespace>Kontur.Selone</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <LangVersion>latest</LangVersion>
     <PackageLicense>https://github.com/skbkontur/Selone/blob/master/LICENSE</PackageLicense>
     <PackageProjectUrl>https://github.com/skbkontur/Selone</PackageProjectUrl>


### PR DESCRIPTION
* Updated to the latest WebDriver version 4.31.0 due to breaking changes. `ElementNotVisibleException` has been removed, so I decided to use `ElementNotInteractableException` instead, as it is the parent class of the removed exception. 
* Method `WebElementWrapper.GetProperty()` is removed, as it was marked obsolete years ago.
* Target frameworks updated to .NET Framework 4.6.2 and .NET 8.0
* Fixed some typos that had been bothering me for years.